### PR TITLE
Add workaround

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,18 @@
             <version>5.6.0-RC1</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.6.0-RC1</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <version>1.6.0-RC1</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -32,6 +44,10 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>3.0.0-M4</version>
+                    <configuration>
+                        <!-- required due to https://github.com/apache/maven-surefire/pull/263 -->
+                        <argLine>--add-exports org.junit.platform.commons/org.junit.platform.commons.util=ALL-UNNAMED</argLine>
+                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,4 +1,6 @@
 module com.example {
     requires org.junit.jupiter.api;
+    requires org.junit.jupiter.engine;
+    requires org.junit.platform.launcher;
     opens com.example;
 }


### PR DESCRIPTION
Surefire uses plexus-java to determine which jars to put on the module or class path. It puts jars defined in `module-info.java` and their dependencies on the module path. Thus, adding the Launcher and the Jupiter engine causes all JUnit jars to be on the module path. However, that in turn causes another error because Surefire uses an internal class from junit-platform-commons that's in a non-exported package. Thus, I added a `--add-exports` arg to the pom.